### PR TITLE
Add package build commands and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,30 @@ chmod +x stealth-run.sh
 
 **IMPORTANT**: The application window will be invisible by default! Use Ctrl+B (or Cmd+B on Mac) to toggle visibility.
 
+### Building Distributable Packages
+
+To create installable packages for distribution:
+
+**For macOS (DMG):**
+```bash
+# Using npm
+npm run package-mac
+
+# Or using yarn
+yarn package-mac
+```
+
+**For Windows (Installer):**
+```bash
+# Using npm
+npm run package-win
+
+# Or using yarn
+yarn package-win
+```
+
+The packaged applications will be available in the `release` directory.
+
 **What the scripts do:**
 - Create necessary directories for the application
 - Clean previous builds to ensure a fresh start

--- a/package.json
+++ b/package.json
@@ -7,7 +7,10 @@
     "dev": "cross-env NODE_ENV=development npm run clean && concurrently \"tsc -w -p tsconfig.electron.json\" \"vite\" \"wait-on -t 30000 http://localhost:54321 && electron ./dist-electron/main.js\"",
     "start": "cross-env NODE_ENV=development concurrently \"tsc -p tsconfig.electron.json\" \"vite\" \"wait-on -t 30000 http://localhost:54321 && electron ./dist-electron/main.js\"",
     "build": "cross-env NODE_ENV=production rimraf dist dist-electron && vite build && tsc -p tsconfig.electron.json",
-    "run-prod": "cross-env NODE_ENV=production electron ./dist-electron/main.js"
+    "run-prod": "cross-env NODE_ENV=production electron ./dist-electron/main.js",
+    "package": "yarn build && electron-builder build",
+    "package-mac": "yarn build && electron-builder build --mac",
+    "package-win": "yarn build && electron-builder build --win"
   },
   "build": {
     "appId": "com.chunginlee.interviewcoder",


### PR DESCRIPTION
## Changes Made

This PR adds packaging commands for creating distributable versions of the application and improves documentation:

### Added Package Build Commands
- Added `package-mac` command to build macOS DMG files
- Added `package-win` command to build Windows installers
- Added `package` command for current platform

### Documentation Updates
- Added a dedicated "Building Distributable Packages" section in README

### Testing Performed
- Verified package commands work correctly on macOS
- Verified package commands work correctly on Windows
- Confirmed documentation accurately reflects the build process

These changes make it easier for users to create distributable versions of the application without having to manually run electron-builder commands.