### PR TITLE
Add Wayland screenshot support with GNOME-specific handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ Note: The application is **NOT** invisible to:
     - No additional permissions needed
   - On Linux:
     - May require `xhost` access depending on your distribution
+    - If using wayland: install `grim`
+    - If using gnome: install `gnome-screenshot` (if not already installed)
 
 ## Running the Application
 


### PR DESCRIPTION
Implemented screenshot capture for Wayland environments, including specific handling for GNOME using `gnome-screenshot`. Added fallback to `grim` for non-GNOME Wayland setups, ensuring compatibility with various Linux desktop environments. Improved error handling and temporary file cleanup.