### PR TITLE
dedicated interactivity/click-through toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ All it takes is modest JavaScript/TypeScript knowledge and understanding of the 
 The application uses unidentifiable global keyboard shortcuts that won't be detected by browsers or other applications:
 
 - Toggle Window Visibility: [Control or Cmd + B]
+- Toggle Window Interactivity: [Control or Cmd + U]
 - Move Window: [Control or Cmd + Arrow keys]
 - Take Screenshot: [Control or Cmd + H]
 - Delete Last Screenshot: [Control or Cmd + L]
@@ -145,6 +146,7 @@ chmod +x stealth-run.sh
 ```
 
 **IMPORTANT**: The application window will be invisible by default! Use Ctrl+B (or Cmd+B on Mac) to toggle visibility.
+               The application window will be non-interactive by default! Use Ctrl+U (or Cmd+U on Mac) to toggle interactivity.
 
 ### Building Distributable Packages
 
@@ -244,6 +246,7 @@ The packaged applications will be available in the `release` directory.
 5. **Window Management**
    - Move window using [Control or Cmd + Arrow keys]
    - Toggle visibility with [Control or Cmd + B]
+   - Toggle interactivity with [Control or Cmd + U]
    - Adjust opacity with [Control or Cmd + [] and [Control or Cmd + ]]
    - Window remains invisible to specified screen sharing applications
    - Start a new problem using [Control or Cmd + R]

--- a/electron/shortcuts.ts
+++ b/electron/shortcuts.ts
@@ -148,6 +148,14 @@ export class ShortcutsHelper {
         mainWindow.webContents.setZoomLevel(currentZoom + 0.5)
       }
     })
+
+    globalShortcut.register("CommandOrControl+U", () => {
+      console.log("Command/Ctrl + U pressed. Click-through enabled.")
+      const mainWindow = this.deps.getMainWindow()
+      if (mainWindow) {
+        this.deps.toggleClickThrough()
+      }
+    })
     
     // Delete last screenshot shortcut
     globalShortcut.register("CommandOrControl+L", () => {

--- a/src/components/Settings/SettingsDialog.tsx
+++ b/src/components/Settings/SettingsDialog.tsx
@@ -463,6 +463,9 @@ export function SettingsDialog({ open: externalOpen, onOpenChange }: SettingsDia
               <div className="grid grid-cols-2 gap-y-2 text-xs">
                 <div className="text-white/70">Toggle Visibility</div>
                 <div className="text-white/90 font-mono">Ctrl+B / Cmd+B</div>
+
+                <div className="text-white/70">Toggle Interactivity</div>
+                <div className="text-white/90 font-mono">Ctrl+U / Cmd+U</div>
                 
                 <div className="text-white/70">Take Screenshot</div>
                 <div className="text-white/90 font-mono">Ctrl+H / Cmd+H</div>


### PR DESCRIPTION
1. Starts the app with click-through mode to eliminate accidental cursor changes, with option to enable interactivity
2. When I tried and tested the tool by setting up calls through browser, and dedicated applications like teams and zoom, the issue my friend noticed on the other side of call was, sudden cursor(pointer) change and elements not being highlighted/focused even when my cursor is on the element. (solves mouse-tracking issue discussed in issue #88)
3. When I want to type the solution in the code editor area, sometimes the application window overlaps, and I cannot click through, toggling with ctrl+B everytime, doesn't feel the best way to do it. This feature allows me to interact with the screen below freely and interact with the application window only when necessary.
4. I'm pushing it as I feel this is a good addition to improve stealth of the tool.

@bhaumikmaan @Ornithopter-pilot 